### PR TITLE
feat: add new fields to the Compact traits supported type list

### DIFF
--- a/crates/storage/codecs/derive/src/compact/generator.rs
+++ b/crates/storage/codecs/derive/src/compact/generator.rs
@@ -104,6 +104,8 @@ fn generate_from_compact(fields: &FieldList, ident: &Ident, is_zstd: bool) -> To
         "Base64",
         "PoaData",
         "IrysSignature",
+        "IrysTokenPrice",
+        "VDFLimiterInfo",
     ];
 
     // Only types without `Bytes` should be added here. It's currently manually added, since


### PR DESCRIPTION
Add IrysTokenPrice and VDFLimiterInfo to the Compact traits supported known type list.

Prerequisite for https://github.com/Irys-xyz/irys/pull/217