### PR TITLE
feat: add extra types to the `known_types` list

### DIFF
--- a/crates/storage/codecs/derive/src/compact/generator.rs
+++ b/crates/storage/codecs/derive/src/compact/generator.rs
@@ -106,6 +106,7 @@ fn generate_from_compact(fields: &FieldList, ident: &Ident, is_zstd: bool) -> To
         "IrysSignature",
         "IrysTokenPrice",
         "VDFLimiterInfo",
+        "PartitionHash",
     ];
 
     // Only types without `Bytes` should be added here. It's currently manually added, since


### PR DESCRIPTION
This is needed to add RLP support to `IrysBlockHeader`.

One of the internal types [(Partition Hash)](https://github.com/Irys-xyz/irys/blob/e64b7b936e11323dbf46f203ba342181e9462ee3/crates/types/src/partition.rs?plain=1#L11-L20) requires Optional<u64> to be listed at the end of the struct because of `#[rlp(trailing)]`, but then `Compact` fails because the unknown type (`PartitionHash`) is not listed at the end. 

This PR makes the PartitionHash known to the Compact trait.