### PR TITLE
remove tables_to_generic! macro

### DIFF
--- a/crates/storage/db/src/tables/mod.rs
+++ b/crates/storage/db/src/tables/mod.rs
@@ -267,33 +267,6 @@ macro_rules! tables {
                 pub(super) const $name: &'static str = stringify!($name);
             )*
         }
-
-        /// Maps a run-time [`Tables`] enum value to its corresponding compile-time [`Table`] type.
-        ///
-        /// This is a simpler alternative to [`TableViewer`].
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use reth_db::{Tables, tables_to_generic};
-        /// use reth_db_api::table::Table;
-        ///
-        /// let table = Tables::Headers;
-        /// let result = tables_to_generic!(table, |GenericTable| GenericTable::NAME);
-        /// assert_eq!(result, table.name());
-        /// ```
-        macro_rules! _tables_to_generic {
-            ($table:expr, |$generic_name:ident| $e:expr) => {
-                match $table {
-                    $(
-                        Tables::$name => {
-                            use $crate::tables::$name as $generic_name;
-                            $e
-                        },
-                    )*
-                }
-            };
-        }
     };
 }
 


### PR DESCRIPTION
`tables_to_generic` macro removed.

`tables_to_generic` contained a code example that fails to compile when running `cargo test --doc`.
`tables` macro was previously refactored out of reth fork as using it multiple times caused a compile error.
Within `tables!`, a `tables_to_generic!` macro is defined and is now unused. The simplest solution may simply be to delete it.